### PR TITLE
fix: chartkickを正しくimportする

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -6,7 +6,11 @@
 
 // Import modules
 import Highcharts from "highcharts";
-import Chartkick from "chartkick";
+import * as Chartkick from "chartkick";
+import Chart from "chart.js";
+
+window.Chartkick = Chartkick;
+Chartkick.use(Chart);
 import "@hotwired/turbo-rails";
 import "@hotwired/stimulus";
 import "@hotwired/stimulus-loading";


### PR DESCRIPTION
## 背景
```
Uncaught SyntaxError: The requested module 'chartkick' does not provide an export named 'default' 
(at application-265bf660.js:9:8)

```

## 対応内容
- fix: chartkickを正しくimportする
  - chartkick モジュールが default export を提供していないため
