### PR TITLE
fix: chart.jsをpinしてやる

### DIFF
--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -2,6 +2,7 @@
 pin "application"
 pin "highcharts", to: "https://code.highcharts.com/highcharts.js" # @12.1.2
 pin "chartkick", to: "https://cdn.jsdelivr.net/npm/chartkick@5.0.1/dist/chartkick.min.js" # @5.0.1
+pin "chart.js", to: "https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.js"
 pin "@hotwired/turbo-rails", to: "turbo.min.js"
 pin "@hotwired/stimulus", to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"


### PR DESCRIPTION
## 背景
```
Uncaught TypeError: Failed to resolve module specifier "chart.js". Relative references must start with either "/", "./", or "../".
```