### PR TITLE
fix: chart.jsをcdn経由で取得するのをやめる

### DIFF
--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -2,7 +2,7 @@
 pin "application"
 pin "highcharts", to: "https://code.highcharts.com/highcharts.js" # @12.1.2
 pin "chartkick", to: "https://cdn.jsdelivr.net/npm/chartkick@5.0.1/dist/chartkick.min.js" # @5.0.1
-pin "chart.js", to: "https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.js"
+pin 'chart.js', to: 'https://ga.jspm.io/npm:chart.js@4.4.6/dist/chart.js'
 pin "@hotwired/turbo-rails", to: "turbo.min.js"
 pin "@hotwired/stimulus", to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"


### PR DESCRIPTION
ref: https://qiita.com/yoshiki_murakami/items/7a44a093e7810397c999


## 背景
![スクリーンショット 2025-03-08 15 25 00](https://github.com/user-attachments/assets/a3aba887-65d4-43e9-8bcb-87f0df45c490)
